### PR TITLE
Update much-timeout.gemspec to support ruby > 2.5

### DIFF
--- a/much-timeout.gemspec
+++ b/much-timeout.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.required_ruby_version = "~> 2.5"
+  gem.required_ruby_version = ">= 2.5"
 
   gem.add_development_dependency("much-style-guide", ["~> 0.6.0"])
   gem.add_development_dependency("assert",           ["~> 2.19.3"])


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes #NNN

**Proposed changes**
<!-- What does this PR change? How does this impact end users? Are manual or automatic updates required? -->

**Alternatives considered**
<!-- How else could the original issue / use case be addressed? Why did you choose this solution over any others? -->

**Testing steps**
<!-- How can we replicate the issue and verify that this PR fixes it? -->
